### PR TITLE
Perform automated checks earlier

### DIFF
--- a/livelint/pkg/livelint/check_are_there_restart_cycling_pods.go
+++ b/livelint/pkg/livelint/check_are_there_restart_cycling_pods.go
@@ -1,0 +1,34 @@
+package livelint
+
+import (
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+func (n *livelint) checkAreThereRestartCyclingPods(allPods []corev1.Pod) CheckResult {
+	failedChecks := []CheckResult{}
+	for _, pod := range allPods {
+		result := n.checkIsRestartCycling(pod)
+		if result.HasFailed {
+			failedChecks = append(failedChecks, result)
+		}
+	}
+	if len(failedChecks) > 0 {
+		cyclingPodReasons := make([]string, 0, len(failedChecks))
+		for _, result := range failedChecks {
+			for _, reason := range result.Details {
+				cyclingPodReasons = append(cyclingPodReasons, reason)
+			}
+		}
+		return CheckResult{
+			HasFailed: true,
+			Message:   fmt.Sprintf("There are %d Pods which are cycling between running an crashing", len(failedChecks)),
+			Details:   cyclingPodReasons,
+		}
+
+	}
+	return CheckResult{
+		Message: "No Pods are restart cycling",
+	}
+}

--- a/livelint/pkg/livelint/check_is_restart_cycling.go
+++ b/livelint/pkg/livelint/check_is_restart_cycling.go
@@ -35,8 +35,6 @@ func (n *livelint) checkIsRestartCycling(pod corev1.Pod) CheckResult {
 	}
 
 	return CheckResult{
-		Message:      "The Pod is not restarting frequently, cycling between Running and CrashLoopBackOff",
-		Details:      []string{lastUnhealthyMessage},
-		Instructions: "Unknown state",
+		Message: "The Pod is not restarting frequently, cycling between Running and CrashLoopBackOff",
 	}
 }


### PR DESCRIPTION
I think we need to re-order some of the checks. Livelint should do all of the stuff first which can be checked automatically. It should do the "look at the logs" check towards the end of the sequence. This is in contrast to the original flow chart which is geared towards being executed manually by a human. Wdyt?