### PR TITLE
Implement checking of whether resource quotas are hit

### DIFF
--- a/livelint/pkg/livelint/check_are_resource_quotas_hit.go
+++ b/livelint/pkg/livelint/check_are_resource_quotas_hit.go
@@ -1,13 +1,42 @@
 package livelint
 
-func checkAreResourceQuotasHit() CheckResult {
-	yes := askUserYesOrNo("Are you hitting the ResourceQuota limits?")
+import (
+	"context"
+	"fmt"
+	"log"
+	"strings"
 
-	if yes {
-		return CheckResult{
-			HasFailed:    true,
-			Message:      "You are hitting the ResourceQuota limits",
-			Instructions: "Relax the ResourceQuota limits",
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func (n *livelint) checkAreResourceQuotasHit(namespace string, deploymentName string) CheckResult {
+	replicaSets, err := n.k8s.AppsV1().ReplicaSets(namespace).List(context.Background(), metav1.ListOptions{})
+	if err != nil {
+		log.Fatal(fmt.Errorf("error when querying replica set for deployment %s in namespace %s: %w", deploymentName, namespace, err))
+	}
+	for _, rs := range replicaSets.Items {
+		isPartOfDeployment := false
+		for _, ownerRef := range rs.ObjectMeta.OwnerReferences {
+			if ownerRef.Kind == "Deployment" && ownerRef.Name == deploymentName {
+				isPartOfDeployment = true
+			}
+		}
+		if !isPartOfDeployment {
+			continue
+		}
+
+		if rs.Status.AvailableReplicas != *rs.Spec.Replicas {
+			for _, condition := range rs.Status.Conditions {
+				if condition.Type == appsv1.ReplicaSetReplicaFailure && strings.Contains(condition.Message, "exceeded quota:") {
+					return CheckResult{
+						HasFailed:    true,
+						Message:      "You are hitting the resource quota limits",
+						Instructions: "Investigate and relax the resource quota limits of the namespace or lower the resources required by some of your workloads in the namespace.",
+						Details:      []string{condition.Message},
+					}
+				}
+			}
 		}
 	}
 

--- a/livelint/pkg/livelint/run_checks.go
+++ b/livelint/pkg/livelint/run_checks.go
@@ -19,20 +19,20 @@ func (n *livelint) RunChecks(namespace, deploymentName string, isVerbose bool) e
 		return fmt.Errorf("error getting Pods: %w", err)
 	}
 
+	// Are you hitting the ResourceQuota limits ?
+	result := n.checkAreResourceQuotasHit(namespace, deploymentName)
+	result.PrettyPrint(isVerbose)
+	if result.HasFailed {
+		return nil
+	}
+
 	// Is there any PENDING Pod?
-	result := checkAreTherePendingPods(allPods)
+	result = checkAreTherePendingPods(allPods)
 	result.PrettyPrint(isVerbose)
 	if result.HasFailed {
 
 		// Is the cluster full?
 		result = n.checkIsClusterFull(allPods)
-		result.PrettyPrint(isVerbose)
-		if result.HasFailed {
-			return nil
-		}
-
-		// Are you hitting the ResourceQuota limits ?
-		result = checkAreResourceQuotasHit()
 		result.PrettyPrint(isVerbose)
 		if result.HasFailed {
 			return nil

--- a/livelint/testdata/resource-quota-test.yml
+++ b/livelint/testdata/resource-quota-test.yml
@@ -1,0 +1,61 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: app-benchmark-quota-test
+---
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  namespace: app-benchmark-quota-test
+  name: cpu-quota
+spec:
+  hard:
+    cpu: "150m"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cpu-quota-exceeding
+  namespace: app-benchmark-quota-test
+  labels:
+    app: cpu-quota-exceeding
+spec:
+  replicas: 2
+  template:
+    metadata:
+      name: cpu-quota-exceeding
+      labels:
+        app: cpu-quota-exceeding
+    spec:
+      containers:
+        - name: awesome-node
+          image: bespinian/awesome-node:1.0.6
+          env:
+            - name: "HEALTHCHECK_LEAK_MEMORY"
+              value: "FALSE"
+            - name: "HEALTHCHECK_LEAK_INCREMENT_KB"
+              value: "0"
+          resources:
+            limits:
+              cpu: "100m"
+              memory: 120M
+            requests:
+              cpu: "100m"
+              memory: 120M
+          ports:
+            - containerPort: 8080
+          livenessProbe:
+            httpGet:
+              path: /healthcheck
+              port: 8080
+            initialDelaySeconds: 10
+            periodSeconds: 5
+          readinessProbe:
+            httpGet:
+              path: /healthcheck
+              port: 8080
+            initialDelaySeconds: 5
+            periodSeconds: 2
+  selector:
+    matchLabels:
+      app: cpu-quota-exceeding


### PR DESCRIPTION
Adds the check whether resource quotas are being hit for that deployment.
The check has been moved to before checking whether pods are pending, because when resource quotas would be exceeded, no pod object is even created.