### PR TITLE
Add check for port forwarding to services

### DIFF
--- a/livelint/pkg/livelint/ask_user_for_service_name.go
+++ b/livelint/pkg/livelint/ask_user_for_service_name.go
@@ -2,14 +2,32 @@ package livelint
 
 import (
 	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
 )
 
-func askUserForServiceName() string {
+func askUserForServiceName(exactlyMatching, partlyMatching []corev1.Service) corev1.Service {
 	fmt.Println("")
-	fmt.Println("Which service should expose this deployment?")
+	fmt.Println("Matching services:")
+	for i, service := range exactlyMatching {
+		fmt.Printf("%v. %v \n", i+1, service.Name)
+	}
+	fmt.Println("")
+	fmt.Println("Partly matching services:")
+	for j, service := range partlyMatching {
+		fmt.Printf("%v. %v \n", len(exactlyMatching)+j+1, service.Name)
+	}
+	fmt.Println("")
+	fmt.Println("Which service would you like to check?")
 
-	var input string
+	var input int
+	var service corev1.Service
 	fmt.Scanln(&input)
 
-	return input
+	if 1 <= input && input <= len(exactlyMatching) {
+		service = exactlyMatching[input-1]
+	} else if len(exactlyMatching) < input && input <= len(partlyMatching) {
+		service = partlyMatching[len(exactlyMatching)-input-1]
+	}
+	return service
 }

--- a/livelint/pkg/livelint/get_deployment.go
+++ b/livelint/pkg/livelint/get_deployment.go
@@ -1,0 +1,18 @@
+package livelint
+
+import (
+	"context"
+	"fmt"
+
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// getDeployment returns the deployment which is targeted.
+func (n *Livelint) getDeployment(namespace, deploymentName string) (*appsv1.Deployment, error) {
+	deployment, err := n.k8s.AppsV1().Deployments(namespace).Get(context.Background(), deploymentName, metav1.GetOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("error getting deployment %q in namespace %q: %w", deploymentName, namespace, err)
+	}
+	return deployment, nil
+}

--- a/livelint/pkg/livelint/get_pods.go
+++ b/livelint/pkg/livelint/get_pods.go
@@ -4,25 +4,36 @@ import (
 	"context"
 	"fmt"
 
-	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
+	v1core "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 )
 
-// getPods returns all pods of a deployment.
-func (n *Livelint) getPods(namespace, deploymentName string) ([]corev1.Pod, error) {
-	deployment, err := n.k8s.AppsV1().Deployments(namespace).Get(context.Background(), deploymentName, metav1.GetOptions{})
+// getPodsForDeployment returns all pods of a deployment.
+func (n *Livelint) getPodsForDeployment(namespace, deploymentName string) ([]v1core.Pod, error) {
+	deployment, err := n.getDeployment(namespace, deploymentName)
 	if err != nil {
-		return nil, fmt.Errorf("error getting deployment %q in namespace %q: %w", deploymentName, namespace, err)
+		return nil, err
 	}
-
 	matchLabels := deployment.Spec.Selector.MatchLabels
+	return n.getPods(namespace, matchLabels)
+}
+
+// getPodsForService returns all pods which are selected by a service.
+func (n *Livelint) getPodsForService(service v1.Service) ([]v1core.Pod, error) {
+	matchLabels := service.Spec.Selector
+	return n.getPods(service.Namespace, matchLabels)
+}
+
+// getPods returns all pods which are selected by a map of labels.
+func (n *Livelint) getPods(namespace string, matchLabels map[string]string) ([]v1core.Pod, error) {
 	options := metav1.ListOptions{
 		LabelSelector: labels.Set(matchLabels).String(),
 	}
 	pods, err := n.k8s.CoreV1().Pods(namespace).List(context.Background(), options)
 	if err != nil {
-		return []corev1.Pod{}, fmt.Errorf("error listing pods: %w", err)
+		return []v1core.Pod{}, fmt.Errorf("error listing pods: %w", err)
 	}
 
 	return pods.Items, nil

--- a/livelint/pkg/livelint/get_services.go
+++ b/livelint/pkg/livelint/get_services.go
@@ -1,0 +1,52 @@
+package livelint
+
+import (
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// isSubmap checks whether all elements of map sourceMatchLabels are also elements of the map targetMatchLabels (i.e. the source labels select the same or more pods).
+func isSubmap(sourceMatchLabels, targetMatchLabels map[string]string) bool {
+	result := true
+	for key, value := range sourceMatchLabels {
+		if targetMatchLabels[key] != value {
+			result = false
+			break
+		}
+	}
+	return result
+}
+
+// getServices gets a list of all services which select the same pods as the target deployment. It also returns
+// a list of all services which potential match a superset of pods. This is useful for warning the user.
+func (n *Livelint) getServices(namespace, deploymentName string) ([]corev1.Service, []corev1.Service, error) {
+	deployment, err := n.getDeployment(namespace, deploymentName)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	deploymentMatchLabels := deployment.Spec.Selector.MatchLabels
+
+	allServices, err := n.k8s.CoreV1().Services(namespace).List(context.Background(), metav1.ListOptions{})
+	if err != nil {
+		return nil, nil, fmt.Errorf("error listing services in namespace %q: %w", namespace, err)
+	}
+	exactlyMatchingServices := []corev1.Service{}
+	supersetMatchingServices := []corev1.Service{}
+	serviceLabelsSubsetDeploymentLabels := false
+	deploymentLabelsSubsetServiceLabels := false
+	for _, service := range allServices.Items {
+		serviceMatchLabels := service.Spec.Selector
+		deploymentLabelsSubsetServiceLabels = isSubmap(serviceMatchLabels, deploymentMatchLabels)
+		serviceLabelsSubsetDeploymentLabels = isSubmap(deploymentMatchLabels, serviceMatchLabels)
+		if serviceLabelsSubsetDeploymentLabels && !deploymentLabelsSubsetServiceLabels {
+			supersetMatchingServices = append(supersetMatchingServices, service)
+		} else if serviceLabelsSubsetDeploymentLabels && deploymentLabelsSubsetServiceLabels {
+			exactlyMatchingServices = append(exactlyMatchingServices, service)
+		}
+	}
+	return exactlyMatchingServices, supersetMatchingServices, nil
+}


### PR DESCRIPTION
We check whether a service is accessible by the following procedure:
- iterate the list of exposed ports on the service, 
- determine the target port of each such port
- check for each pod selected by the service, that we can port-forward to the target port and send a packet