### PR TITLE
Add check for port mismatch

### DIFF
--- a/livelint/pkg/livelint/check_target_port_matches_container_port.go
+++ b/livelint/pkg/livelint/check_target_port_matches_container_port.go
@@ -1,18 +1,54 @@
 package livelint
 
-func checkTargetPortMatchesContainerPort() CheckResult {
-	yes := askUserYesOrNo("Is the targetPort on the Service matching the containerPort in the Pod?")
+import (
+	"context"
+	"fmt"
+	"log"
+	"strings"
 
-	if !yes {
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func (n *Livelint) checkTargetPortMatchesContainerPort(allPods []corev1.Pod, serviceName string, namespace string) CheckResult {
+	service, err := n.k8s.CoreV1().Services(namespace).Get(context.Background(), serviceName, metav1.GetOptions{})
+	if err != nil {
+		log.Fatal(fmt.Errorf("error getting service %s in namespace %s: %w", serviceName, namespace, err))
+	}
+
+	unexposedPorts := []string{}
+	firstPod := allPods[0]
+	for _, servicePort := range service.Spec.Ports {
+		portIsExposed := false
+		for _, container := range firstPod.Spec.Containers {
+			for _, containerPort := range container.Ports {
+				if containerPort.ContainerPort == servicePort.TargetPort.IntVal &&
+					containerPort.Protocol == servicePort.Protocol {
+					portIsExposed = true
+					break
+				}
+			}
+			if portIsExposed {
+				break
+			}
+		}
+		if !portIsExposed {
+			unexposedPorts = append(unexposedPorts, fmt.Sprintf("%s %d", servicePort.Protocol, servicePort.TargetPort.IntVal))
+		}
+	}
+
+	if len(unexposedPorts) > 0 {
+		portList := strings.Join(unexposedPorts, ", ")
+
 		return CheckResult{
 			HasFailed:    true,
-			Message:      "The targetPort on the Service doesn't match the containerPort in the Pod",
+			Message:      fmt.Sprintf("The targetPorts %s on the Service don't match the containerPort in the Pod", portList),
 			Instructions: "Fix the Service targetPort and the containerPort",
 		}
 	}
 
 	return CheckResult{
-		Message:      "The targetPort on the Service matches the containerPort in the Pod",
+		Message:      "The targetPorts on the Service match the containerPorts in the Pod",
 		Instructions: "The issue could be with the Kube Proxy",
 	}
 }

--- a/livelint/pkg/livelint/run_checks.go
+++ b/livelint/pkg/livelint/run_checks.go
@@ -195,7 +195,7 @@ func (n *Livelint) RunChecks(namespace, deploymentName string, isVerbose bool) e
 	if result.HasFailed {
 
 		// Is the targetPort on the Service matching the containerPort in the Pod?
-		result = checkTargetPortMatchesContainerPort()
+		result = n.checkTargetPortMatchesContainerPort(allPods, serviceName, namespace)
 		result.PrettyPrint(isVerbose)
 
 		return nil

--- a/livelint/testdata/port-mismatch-svc.yml
+++ b/livelint/testdata/port-mismatch-svc.yml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: port-mismatch
+  namespace: app-benchmark-test
+spec:
+  ports:
+  - port: 80
+    name: http
+    protocol: TCP
+    targetPort: 8080
+  - port: 1234
+    name: blah
+    protocol: TCP
+    targetPort: 12345
+  selector:
+    app: ok


### PR DESCRIPTION
Checks whether a service's targetPort matches a pod exposed by one of the containers in the deployment