### PR TITLE
Add support for common auth providers

### DIFF
--- a/main.go
+++ b/main.go
@@ -11,6 +11,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/urfave/cli/v2"
 	"k8s.io/client-go/kubernetes"
+	_ "k8s.io/client-go/plugin/pkg/client/auth"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/util/homedir"
 )


### PR DESCRIPTION
This adds support for common auth providers such as OIDC. Without it, livelint would fail with:

```failed to start livelint: error creating k8s client set: no Auth Provider found for name "oidc"exit status 1```

